### PR TITLE
Replace Matlabpool with Parpool

### DIFF
--- a/glmalpha.m
+++ b/glmalpha.m
@@ -207,13 +207,13 @@ if ~(ischar(TH) && ~isempty(strfind(TH(:)','demo')))
       if tl
         if verLessThan('matlab', '8.2')
             % For MATLAB older than MATLAB 8.2, we need to check if the pool is open
-            s=matlabpool('size');
-            if s
+            p=gcp('nocreate');
+            if isempty(p)
+              disp('No open parpool. Running KERNELC (non-parallel).');
+              [Klmlmp]=kernelc(maxL,TH,sord);
+            else
               disp('Running KERNELCP (parallel)');
               [Klmlmp]=kernelcp(maxL,TH,sord);
-            else
-              disp('No open matlabpool. Running KERNELC (non-parallel).');
-              [Klmlmp]=kernelc(maxL,TH,sord);
             end    
         else
             % For MATLAB 8.2 and newer, a parpool should start automatically

--- a/localization.m
+++ b/localization.m
@@ -183,7 +183,7 @@ if ~isstr(L)
     [XY,lonc,latc]=eval(sprintf('%s(%i)',dom,N));
     % h=waitbar(0);
     try
-      matlabpool open 
+      parpool 
     end
     parfor index=1:J
       % This here was changed 10/18/2010 to reflect the changed

--- a/plm2xyz.m
+++ b/plm2xyz.m
@@ -156,14 +156,15 @@ if ~isstr(lmcosi)
 		 fullfile(getenv('IFILES'),'LEGENDRE'),...
 		 ldown,lup,nlat);
     % ONLY COMPLETE LINEARLY SPACED SAMPLED VECTORS ARE TO BE SAVED!
+    p=gcp('nocreate');
     if [exist(fnpl,'file')==2 && length(c11cmn)==4 && all(c11cmn==[0 90 360 -90])]...
 	  & ~[size(els,1)==1 &&  exist('Plm','var')==1]
       % Get Legendre function values at linearly spaced intervals
       disp(sprintf('Using preloaded %s',fnpl))
       load(fnpl)
       % AND TYPICALLY ANYTHING ELSE WOULD BE PRECOMPUTED, BUT THE GLOBAL
-      % ONES CAN TOO! The Matlabpool check doesn't seem to work inside 
-    elseif size(els,1)==1 &&  exist('Plm','var')==1 && matlabpool('size')==0
+      % ONES CAN TOO! The Parpool check doesn't seem to work inside 
+    elseif size(els,1)==1 &&  exist('Plm','var')==1 && isempty(p)
       % disp(sprintf('Using precomputed workspace Legendre functions'))
     else
       % Evaluate Legendre polynomials at selected points


### PR DESCRIPTION
Matlabpool has been deprecated.  This PR is fairly trivial; it replaces instances of Matlabpool in Slepian_Alpha with Parpool, the replacement Matlab created to/for Matlabpool.