### PR TITLE
Removed old syntax for opening a MATLAB parpool, now unnecessary

### DIFF
--- a/localization.m
+++ b/localization.m
@@ -182,9 +182,6 @@ if ~isstr(L)
     % Return the rotation parameters also, to undo later
     [XY,lonc,latc]=eval(sprintf('%s(%i)',dom,N));
     % h=waitbar(0);
-    try
-      parpool 
-    end
     parfor index=1:J
       % This here was changed 10/18/2010 to reflect the changed
       % conventions in PLM2ROT


### PR DESCRIPTION
Based on [this PR](https://github.com/csdms-contrib/slepian_alpha/commit/0cb6dad4cfd8cc89a5f4a50918ed30c32d8ef936#diff-9689e79151ed60589bd45ed3b54a7230) per the suggestion of [this comment](https://github.com/csdms-contrib/slepian_alpha/pull/12#issuecomment-343579294).